### PR TITLE
fix: typo in Selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A curated list of Site Reliability and Production Engineering tools
 - [WebStorm](https://www.jetbrains.com/webstorm/)
 
 ## Continous Testing
-- [Selinium](https://www.seleniumhq.org/)
+- [Selenium](https://www.seleniumhq.org/)
 - [JUnit](https://junit.org/)
 - [TestNG](https://testng.org/doc/index.html)
 - [NUnit](https://nunit.org/)


### PR DESCRIPTION
Fix a typo in Selenium

Before: `Selinium`
After: `Selenium`