### PR TITLE
Adding ArgoCD to the CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ A curated list of Site Reliability and Production Engineering tools
 - [Codar Continous Delivery](https://www.microfocus.com/en-us/products/codar-continuous-deployment/overview)
 - [Wercker](https://app.wercker.com/)
 - [Humanitec](https://humanitec.com/)
+- [ArgoCD](https://argo-cd.readthedocs.io/en/stable/)
 
 ### Infrastructure orchestration
 - [Vagrant](https://www.vagrantup.com/)


### PR DESCRIPTION
Adding ArgoCD to the Deployment section. 

I am not sure if there needs to be a completely different section for GitOps. If so, I am more than happy to edit and resubmit. 