### PR TITLE
Add bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A curated list of Site Reliability and Production Engineering tools
 - [MS Build](https://www.microsoft.com/en-us/build)
 - [Drill](https://gitlab.com/aki237/drill)
 - [Hydra](https://nixos.org/hydra/)
+- [Bazel](https://bazel.io)
 
 ### Integration
 - [Jenkins](https://jenkins.io/)


### PR DESCRIPTION
Bazel its a build tool developed by Google, internally used as Blaze.
Bazel actually has the possibilities to manage many languages builds with Determinism, and Distribuhited caching which allows to easly do CI process even faster.
