### PR TITLE
Add DevHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Mercurial](https://www.mercurial-scm.org/)
 - [Perforce Helix Core](https://www.perforce.com/products/helix-core/)
 - [Subversion (SVN)](https://subversion.apache.org/)
+- [DevHub (Gitea)](https://dev-hub.eu/)
 
 ### Project Management & Issue Tracking Software
 - [Jira](https://www.atlassian.com/software/jira)


### PR DESCRIPTION
DevHub is a source code hosting provider that offers paid and free versions of Gitea, and it has a strong focus on Security, Privacy and Performance.