### PR TITLE
Add Kratix OSS platform/infra orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Pulumi](https://www.pulumi.com/)
 - [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/)
 - [OPS](https://ops.city)
+- [Kratix](https://www.kratix.io/)
 
 ### Container
 - [Docker](https://www.docker.com/)


### PR DESCRIPTION
Add Kratix OSS framework to the infrastructure orchestration section. 

Please shout if you would prefer me to create a new "platform orchestration" section in the doc, as other tools, such as Humanitec and KusionStack, also exist in this space.