### PR TITLE
Add FlareWarden to monitoring tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [CICube](https://cicube.io/) - AI DevOps monitoring platform by monitoring your CI workflows, detect anomalies, and provide actionable fixes.
 - [Middleware](https://middleware.io) - A Full-Stack Cloud Observability Platform designed to empower developers and organizations to monitor, optimize, and streamline their applications and infrastructure in real-time.
 - [Shipfox](https://www.shipfox.io/) - Boost GitHub Actions speed by 2x and cut costs by up to 75%, with smarter caching, deep CI insights, and zero-config setup.
-
+- [FlareWarden](https://flarewarden.com/monitoring) - Uptime, content, and dependency monitoring with multi-region verification, status pages, and incident management.
 
 ## Incident Management / Incident Response / IT Alerting / On-Call
 - [Squadcast](https://www.squadcast.com)


### PR DESCRIPTION
Added FlareWarden to the monitoring tools list in README at the bottom of the Continuous Monitoring section as instructed.