### PR TITLE
Add API Status Check to Continuous Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Zabbix](https://www.zabbix.com/)
 - [InsightOps](https://www.rapid7.com/products/insightops/)
 - [AppSignal](https://appsignal.com)
+- [API Status Check](https://apistatuscheck.com) - Centralized dashboard tracking real-time status and outages for 1,000+ popular APIs and services (AWS, Stripe, GitHub, Twilio, etc.). Monitor third-party dependencies, get instant outage alerts, reduce MTTR.
 - [Grafana](https://grafana.com)
 - [VictoriaMetrics](https://github.com/VictoriaMetrics/VictoriaMetrics/)
 - [Chaos Genius](https://www.chaosgenius.io/)


### PR DESCRIPTION
Adding API Status Check (https://apistatuscheck.com) to the Continuous Monitoring section.

API Status Check is a centralized dashboard tracking real-time status and outages for 1,000+ popular APIs and services (AWS, Stripe, GitHub, Twilio, and more). It helps SREs and DevOps teams monitor third-party dependencies, get instant outage alerts, and reduce MTTR by quickly identifying if issues are internal or caused by external API outages.

Perfect fit for the Continuous Monitoring section alongside similar tools like Better Stack, Healthchecks.io, and OnlineOrNot.