### PR TITLE
Add tailscale-mcp to AI SRE Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to build causal chains explaining GPU latency. Includes MCP server for AI-assisted incident investigation.
 - [IncidentFox](https://github.com/incidentfox/incidentfox) (open source)
 - [metoro.io](https://metoro.io/)
+- [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server with 52 tools for managing Tailscale tailnets from AI assistants like Claude Code and Cursor.
 
 ## Stargazers over time
 


### PR DESCRIPTION
tailscale-mcp is an open-source MCP server that enables AI assistants to manage Tailscale tailnets through 52 tools covering devices, ACL policies, DNS, auth keys, users, webhooks, audit logs, network lock, and posture integrations.

Useful for SRE teams using AI-assisted workflows to manage network infrastructure.

- **GitHub:** https://github.com/YawLabs/tailscale-mcp
- **npm:** `npx @yawlabs/tailscale-mcp`
- **License:** MIT