### PR TITLE
Add Oack to Continuous Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [FlareWarden](https://flarewarden.com/monitoring) - Uptime, content, and dependency monitoring with multi-region verification, status pages, and incident management.
 - [Phare](https://phare.io) - Shockingly good uptime monitoring, alerts, incident management, and status pages.
 - [API Status Check](https://apistatuscheck.com/) - Real-time status monitoring dashboard for 250+ developer APIs including AWS, Stripe, GitHub, and OpenAI. Free, no signup required.
+- [Oack](https://oack.io) - HTTP monitoring with TCP kernel telemetry, 6-phase latency breakdown, Server-Timing header capture, Cloudflare CDN enrichment, and built-in incident management with on-call scheduling.
 
 
 ## Incident Management / Incident Response / IT Alerting / On-Call


### PR DESCRIPTION
Added [Oack](https://oack.io) to the Continuous Monitoring section.

Oack is an HTTP monitoring service with deep network diagnostics — TCP kernel telemetry (RTT, retransmits, congestion window via TCP_INFO), 6-phase latency breakdown, automatic Server-Timing header capture, Cloudflare CDN log enrichment, and built-in incident management with on-call scheduling.