### PR TITLE
Add Snaplert to Continuous Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Ingero](https://github.com/ingero-io/ingero) - eBPF-based GPU causal observability agent. Traces CUDA APIs and host kernel events to build causal chains explaining GPU latency. Includes MCP server for AI-assisted incident investigation.
 - [cloud-audit](https://github.com/gebalamariusz/cloud-audit) - AWS security auditing CLI that runs 17 checks across IAM, S3, EC2, VPC, and RDS with built-in remediation engine generating AWS CLI commands and Terraform snippets.
 - [FlareWarden](https://flarewarden.com/monitoring) - Uptime, content, and dependency monitoring with multi-region verification, status pages, and incident management.
+- [Snaplert](https://snaplert.com) - Website change monitoring with visual pixel diffs, AI summaries (Claude) explaining what changed, and element-level zone picker. Free during open beta.
 - [Phare](https://phare.io) - Shockingly good uptime monitoring, alerts, incident management, and status pages.
 - [API Status Check](https://apistatuscheck.com/) - Real-time status monitoring dashboard for 250+ developer APIs including AWS, Stripe, GitHub, and OpenAI. Free, no signup required.
 


### PR DESCRIPTION
Adds [Snaplert](https://snaplert.com) to the Continuous Monitoring section alongside FlareWarden and other content monitoring tools.

Snaplert monitors webpages for visual changes with pixel-level diffs, AI-powered summaries (Claude) explaining what changed, and an element-level zone picker. Free during open beta.

Useful for monitoring competitor pages, policy changes, compliance docs, and any web content that teams need to track.