### PR TITLE
Add Uptrack to Continuous Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Elastic APM](https://www.elastic.co/apm)
 - [Healthchecks.io](https://healthchecks.io)
 - [OnlineOrNot](https://onlineornot.com/) - Uptime monitoring for websites, APIs, and cron jobs, with integrated status pages.
+- [Uptrack](https://uptrack.app) - Uptime monitoring with 30-second checks on free tier, consecutive-check alert confirmation to cut false positives, hosted status pages, and a built-in MCP server for AI agents.
 - [Streamdal](https://streamdal.com) - Code-Native Data Privacy - embed privacy controls in your application code to detect and monitor PII. [![Streamdal](https://img.shields.io/github/stars/streamdal/streamdal?style=flat-square&logo=github&labelColor=%230D1117&color=%23161B22)](https://github.com/streamdal/streamdal)
 - [Dash0](https://www.dash0.com/) - OpenTelemetry Native Observability, built on CNCF Open Standards such as PromQL, Perses and OTLP with full cost control. Supporting Metrics, Traces and Logs with full custom dashboarding and alerting capabilities.
 - [CICube](https://cicube.io/) - AI DevOps monitoring platform by monitoring your CI workflows, detect anomalies, and provide actionable fixes.


### PR DESCRIPTION
Adds [Uptrack](https://uptrack.app) to the Continuous Monitoring section.

**Why it fits an SRE tools list**:
- Consecutive-check alert confirmation (majority-of-regions vote) — a practical pattern for cutting alert fatigue that SRE teams care about
- 30-second check intervals on the free tier
- HTTP, HTTPS (keyword), SSL, TCP, DNS, Ping, Heartbeat, Cron monitors
- Hosted status pages with custom domains
- Free API + MCP server for AI-assisted incident triage

50 monitors on the free tier forever, no credit card required.