### PR TITLE
Add Qovery to Deployment section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Buddy Works](https://buddy.works/)
 - [werf](https://werf.io/)
 - [Google Cloud Build](https://cloud.google.com/build)
+- [Qovery](https://www.qovery.com/) - Enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway.
 
 ### Infrastructure orchestration
 - [Vagrant](https://www.vagrantup.com/)


### PR DESCRIPTION
Adds [Qovery](https://www.qovery.com) — an enterprise Kubernetes management platform for deploying applications, databases, Helm charts, and Terraform modules on AWS, GCP, Azure, and Scaleway. Includes a Terraform provider, CLI, REST API, and an [AI Agent Skill](https://github.com/Qovery/qovery-skills) for deploying from Claude Code, Cursor, OpenCode, and 30+ AI coding tools.

Website: https://www.qovery.com
GitHub: https://github.com/Qovery
Documentation: https://www.qovery.com/docs/getting-started/introduction