### PR TITLE
docs: add KubeStellar Console to AI SRE Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [metoro.io](https://metoro.io/)
 - [Ops AI by Middleware](https://middleware.io/product/ops-ai/)
 - [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server with 52 tools for managing Tailscale tailnets from AI assistants like Claude Code and Cursor.
+- [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management console with MCP server (kc-agent) for AI-assisted cluster operations, pod inspection, deployment management, and real-time observability across distributed environments.
 
 ## Related Lists
 


### PR DESCRIPTION
## What

Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **AI SRE Tools & SRE Copilots** section.

## Why

KubeStellar Console is an AI-powered multi-cluster Kubernetes management console with:
- **kc-agent** — an MCP (Model Context Protocol) server that bridges AI assistants (Claude, Cursor, Copilot) to live Kubernetes clusters for AI-assisted operations
- Real-time observability and incident-response tooling across distributed environments
- AI chat interface for cluster management, pod inspection, deployment management, and compliance checks

Fits the AI SRE Tools section alongside other MCP-based tools like tailscale-mcp.

## Checklist
- [x] No duplicate entries
- [x] Added at bottom of section
- [x] No dead URLs
- [x] Commit message describes change without marketing language