### PR TITLE
Add NudgeBee to AI SRE Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Ops AI by Middleware](https://middleware.io/product/ops-ai/)
 - [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server with 52 tools for managing Tailscale tailnets from AI assistants like Claude Code and Cursor.
 - [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management console with MCP server (kc-agent) for AI-assisted cluster operations, pod inspection, deployment management, and real-time observability across distributed environments.
+- [NudgeBee](https://nudgebee.com) - Unified AI agentic platform for cloud ops, offering AI SRE, AI FinOps, AI Kubernetes Ops, and AI CloudOps assistants that automate alert triage, root-cause analysis, and cost optimization.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds NudgeBee under AI SRE Tools & SRE Copilots.

NudgeBee is an open-source agentic platform for cloud operations. It provides
AI assistants for SRE, FinOps, Kubernetes, and CloudOps workflows.