### PR TITLE
Add net-benchmark to Continuous Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 ## Continuous Monitoring
 - [AWS CloudWatch](https://aws.amazon.com/cloudwatch/)
 - [DebugBear](https://www.debugbear.com/)
+- [net-benchmark](https://github.com/net-benchmark/net-benchmark) - DNS/HTTP/SSL benchmarking with CSV, Excel, PDF, and JSON exports.
 - [Prometheus](https://prometheus.io/)
 - [StackDriver](https://cloud.google.com/stackdriver/)
 - [Sensu](https://sensu.io/)


### PR DESCRIPTION
Add net-benchmark to the Continuous Monitoring section.

net-benchmark is an open-source DNS/HTTP/SSL benchmarking and diagnostics CLI.
It supports CSV, Excel, PDF, and JSON exports, making it useful for SRE teams
monitoring network latency, resolver performance, and critical service
dependencies.

Project: https://github.com/net-benchmark/net-benchmark
