### PR TITLE
Add ZopNight to Continuous Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Oack](https://oack.io) - HTTP monitoring with TCP kernel telemetry, 6-phase latency breakdown, Server-Timing header capture, Cloudflare CDN enrichment, and built-in incident management with on-call scheduling.
 - [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) - Real-time AI agent monitoring dashboard for OpenClaw agents. Track Gateway status, sessions, token usage & trends.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Track cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates across Claude Code, Codex CLI, Gemini CLI, Aider, and Cursor exports.
+- [ZopNight](https://github.com/zopdev/zopnight) - Multi-cloud (AWS/GCP/Azure) resource scheduler and audit engine. Namespace-level scheduling for EKS, GKE, and AKS. 460 audit rules covering reliability (HPA at max, missing requests/limits), security (privileged containers, host network), idle resources, and rightsizing. Customer databases (RDS, Aurora, Cloud SQL, Azure SQL) excluded from any mutating action.
 
 ## Incident Management / Incident Response / IT Alerting / On-Call
 - [Squadcast](https://www.squadcast.com)


### PR DESCRIPTION
**Section:** Continuous Monitoring

ZopNight continuously monitors cloud resource state and cost across AWS, GCP, and Azure. Resource discovery runs on a 6-hour cron across all three clouds, audit rules are evaluated continuously against discovered resources, and budget thresholds fire notifications when crossed.

Where native monitors stop at uptime and metrics, ZopNight watches for waste signals — idle resources, over-provisioned instances, orphaned storage, and cross-cloud inefficiencies. Customer databases (RDS, Aurora, Cloud SQL, Azure SQL) are explicitly excluded from any mutating action.