### PR TITLE
Add flakybin to Continuous Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Cypress](https://www.cypress.io/)
 - [TestRail](https://www.gurock.com/testrail/)
 - [Bencher](https://bencher.dev)
+- [flakybin](https://github.com/mikluko/flakybin)
 
 ## Continuous Integration
 ### Build


### PR DESCRIPTION
Adds [flakybin](https://github.com/mikluko/flakybin) to the Continuous Testing section.

flakybin is a deterministic HTTP fault-injection server: it fails endpoints (status codes, hangs, connection drops) on a seed-reproducible schedule, so you can point an uptime monitor or retry logic at a known-good failure pattern. Sits alongside steadybit and k6 as a resilience/testing tool. Open source (MIT).

- No duplicate entry
- Added at the bottom of the section (Continuous Testing)
- Live URL, matches the section's `- [Name](link)` format