### PR TITLE
Remove dead link: CodeLobster

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [PyCharm](https://www.jetbrains.com/pycharm/)
 - [Eclipse Che](https://www.eclipse.org/che/)
 - [Bluefish](https://bluefish.openoffice.nl/index.html)
-- [CodeLobster](https://codelobster.com/)
 
 ## Continuous Testing
 - [Selenium](https://www.seleniumhq.org/)


### PR DESCRIPTION
Removes the CodeLobster entry from Code Editors and IDEs — its domain is no longer active.

Evidence:
- `https://codelobster.com/` does not resolve: DNS lookup returns SERVFAIL (no A/AAAA record).
- `curl` fails with exit code 6 (could not resolve host); no HTTP response.

Per the contributing guidelines ("Make sure there are no dead url's"), removing it.