### PR TITLE
Add KnoxOps to AI SRE Tools & SRE Copilots

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Ops AI by Middleware](https://middleware.io/product/ops-ai/)
 - [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server with 52 tools for managing Tailscale tailnets from AI assistants like Claude Code and Cursor.
 - [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management console with MCP server (kc-agent) for AI-assisted cluster operations, pod inspection, deployment management, and real-time observability across distributed environments.
+- [KnoxOps](https://knoxops.app/?invite_token=GITHUB26) - AI-native ops agent that gives agents production-safe execution with human review and a built-in knowledge graph.
 
 ## Related Lists
 


### PR DESCRIPTION
KnoxOps is an AI-native ops agent for SREs. It gives AI agents production execution power within safety guardrails — every change requires human review, complex operations need a plan with AI reviewing each stage, and it maintains a built-in knowledge graph of your production infrastructure.

Currently invite-only. The invite_token=GITHUB26 in the URL provides instant access for reviewers.