### PR TITLE
Add Radar to AI SRE Tools & SRE Copilots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Ops AI by Middleware](https://middleware.io/product/ops-ai/)
 - [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server with 52 tools for managing Tailscale tailnets from AI assistants like Claude Code and Cursor.
 - [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management console with MCP server (kc-agent) for AI-assisted cluster operations, pod inspection, deployment management, and real-time observability across distributed environments.
+- [Radar](https://github.com/skyhook-io/radar) - Open source Kubernetes visibility tool with a built-in MCP server for AI-assisted cluster operations — topology, service traffic, events, logs, and a 31-check best-practices audit.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds [Radar](https://github.com/skyhook-io/radar) to the **AI SRE Tools & SRE Copilots** section, alongside KubeStellar Console and tailscale-mcp.

Radar is an open-source (Apache-2.0) Kubernetes visibility tool with a built-in MCP server for AI-assisted cluster operations — topology, service traffic, events, logs, and a 31-check best-practices audit. Added at the bottom of the section per CONTRIBUTING.md.