### PR TITLE
Add Anyshift to AI SRE Tools & SRE Copilots

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Ops AI by Middleware](https://middleware.io/product/ops-ai/)
 - [tailscale-mcp](https://github.com/YawLabs/tailscale-mcp) - MCP server with 52 tools for managing Tailscale tailnets from AI assistants like Claude Code and Cursor.
 - [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes management console with MCP server (kc-agent) for AI-assisted cluster operations, pod inspection, deployment management, and real-time observability across distributed environments.
+- [Anyshift](https://www.anyshift.io/) - AI SRE built on a versioned resource graph of your infrastructure, for root cause analysis and predicting the impact of changes before they ship.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds [Anyshift](https://www.anyshift.io/) to the **AI SRE Tools & SRE Copilots** section.

Anyshift is an AI SRE built on a versioned resource graph of your infrastructure, used for root cause analysis and predicting the impact of changes before they ship.

Entry matches the existing list style (name, link, one-line description).