### PR TITLE
Add OpenChainBench to Continuous Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Oack](https://oack.io) - HTTP monitoring with TCP kernel telemetry, 6-phase latency breakdown, Server-Timing header capture, Cloudflare CDN enrichment, and built-in incident management with on-call scheduling.
 - [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) - Real-time AI agent monitoring dashboard for OpenClaw agents. Track Gateway status, sessions, token usage & trends.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Track cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates across Claude Code, Codex CLI, Gemini CLI, Aider, and Cursor exports.
+- [OpenChainBench](https://openchainbench.com) - Continuous monitoring of blockchain RPC providers, bridges and oracles. Multi-region Prometheus probes of latency, tx-landing success and finality with public dashboards and open methodology.
 
 ## Incident Management / Incident Response / IT Alerting / On-Call
 - [Squadcast](https://www.squadcast.com)


### PR DESCRIPTION
Adds OpenChainBench under Continuous Monitoring. It runs multi-region Prometheus probes of blockchain RPC providers, bridges and oracles with public dashboards. Methodology and harness code are open source.

Thanks for maintaining the list.