### PR TITLE
feat(monitoring): add Prismix AI service status monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Riftmap](https://riftmap.dev) - Cross-repo infrastructure dependency discovery and change impact analysis for multi-repo environments using Terraform, Docker, Helm, and more.
 - [Oack](https://oack.io) - HTTP monitoring with TCP kernel telemetry, 6-phase latency breakdown, Server-Timing header capture, Cloudflare CDN enrichment, and built-in incident management with on-call scheduling.
 - [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) - Real-time AI agent monitoring dashboard for OpenClaw agents. Track Gateway status, sessions, token usage & trends.
+- [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Google Gemini, Cursor, Groq). Free REST API, email/webhook alerts, 30-day uptime history.
 - [agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents. Track cost, tokens, tool failures, latency, anomalies, health, diffs, and CI gates across Claude Code, Codex CLI, Gemini CLI, Aider, and Cursor exports.
 
 ## Incident Management / Incident Response / IT Alerting / On-Call


### PR DESCRIPTION
## What

Adds **Prismix** to the monitoring section — real-time status tracking for 75+ AI services (OpenAI, Anthropic, Google Gemini, Cursor, Groq, Mistral, and more).

## Why it fits

SRE teams increasingly depend on AI APIs in their production stacks. When ChatGPT or Claude goes down, it affects downstream services just like any other dependency. Prismix gives SREs a single pane of glass for AI API health — uptime history, incident timelines, email/webhook alerts, and a free REST API at `GET /api/v1/statuses`.

## Entry added

**Monitoring** section:
```
- [Prismix](https://prismix.dev) - Real-time status monitoring and incident tracking for 75+ AI services (OpenAI, Anthropic, Google Gemini, Cursor, Groq). Free REST API, email/webhook alerts, 30-day uptime history.
```