### PR TITLE
Add Aient AI to AI SRE Tools & SRE Copilots

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [KnoxOps](https://knoxops.app/?invite_token=GITHUB26) - AI-native ops agent that gives agents production-safe execution with human review and a built-in knowledge graph.
 - [NudgeBee](https://nudgebee.com) - Unified AI agentic platform for cloud ops, offering AI SRE, AI FinOps, AI Kubernetes Ops, and AI CloudOps assistants that automate alert triage, root-cause analysis, and cost optimization.
 - [Hyground](https://hyground.ai) - Self-hosted AI SRE agent that goes beyond on-call incident resolution.
+- [Aient AI](https://aient.ai) - OpenTelemetry-native AI SRE agent that ingests logs, metrics, and traces, groups errors into problems, investigates root cause, and opens a GitHub pull request with a fix, then monitors production telemetry for recurrence. Integrates with GitHub, Slack, and Linear, and exposes a hosted MCP server. ([docs](https://docs.aient.ai))
 
 ## Related Lists
 


### PR DESCRIPTION
Adds one entry under **AI SRE Tools & SRE Copilots**, at the bottom of the section per CONTRIBUTING.md.

**Disclosure:** I work on Aient AI — this is a vendor self-submission.

### Entry
```
- [Aient AI](https://aient.ai) - OpenTelemetry-native AI SRE agent that ingests logs, metrics, and traces, groups errors into problems, investigates root cause, and opens a GitHub pull request with a fix, then monitors production telemetry for recurrence. Integrates with GitHub, Slack, and Linear, and exposes a hosted MCP server. ([docs](https://docs.aient.ai))
```

### What it is
Aient AI ingests OTLP telemetry (logs, metrics, traces), groups recurring errors into problems, and runs an AI agent that investigates root cause and opens a GitHub pull request with a proposed fix. The pull request is the human approval gate — Aient does not merge or deploy to production itself. After merge it passively checks production telemetry for recurrence of the problem.

Commercial, early-access, closed-source. Homepage https://aient.ai, docs https://docs.aient.ai.

### Checklist
- No duplicate entry (searched for existing Aient/Glimt — none).
- Added at the bottom of the section.
- Both URLs verified live (200).