### PR TITLE
Add Screpy to Continuous Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Faultline](https://github.com/faultline-cli/faultline) - Deterministic CI failure analysis CLI that classifies build logs into explainable failure types with evidence and fix steps.
 - [Oh Dear](https://ohdear.app) - Monitoring for uptime, performance, broken links, SSL certificates, and DNS, with hosted status pages.
 - [Yorker](https://yorkermonitoring.com) - OpenTelemetry-native synthetic monitoring with HTTP and Playwright browser checks, monitoring-as-code via YAML and CLI, and enriched OTLP export to any OTel backend.
+- [Screpy](https://screpy.com/) - Monitors website availability, page speed, and Core Web Vitals alongside technical SEO checks.
 
 ## Incident Management / Incident Response / IT Alerting / On-Call
 - [Squadcast](https://www.squadcast.com)


### PR DESCRIPTION
## Summary

Adds [Screpy](https://screpy.com/) to the Continuous Monitoring section.

## Why

The entry describes the relevant website monitoring capabilities: Core Web Vitals, page speed, uptime, and technical SEO checks.

## Validation

- Confirmed the official link is publicly reachable.
- Confirmed this list does not already contain Screpy.
- Checked the diff: one README-only addition (seven lines where the repository's entry format requires feature bullets).

Affiliation: submitted on behalf of Screpy.
