### PR TITLE
Add MB3R Stack to Continuous Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [Faultline](https://github.com/faultline-cli/faultline) - Deterministic CI failure analysis CLI that classifies build logs into explainable failure types with evidence and fix steps.
 - [Oh Dear](https://ohdear.app) - Monitoring for uptime, performance, broken links, SSL certificates, and DNS, with hosted status pages.
 - [Yorker](https://yorkermonitoring.com) - OpenTelemetry-native synthetic monitoring with HTTP and Playwright browser checks, monitoring-as-code via YAML and CLI, and enriched OTLP export to any OTel backend.
+- [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) - Open-source model-based resilience toolchain using telemetry-driven topology discovery and virtual failure simulation for continuous resilience assessment and pre-release risk analysis.
 
 ## Incident Management / Incident Response / IT Alerting / On-Call
 - [Squadcast](https://www.squadcast.com)


### PR DESCRIPTION
Adds [MB3R Stack](https://github.com/MB3R-Lab/mb3r-stack) to **Continuous Monitoring**.

MB3R Stack is an open-source model-based resilience toolchain for distributed systems. It uses telemetry-derived topology as an executable model and evaluates virtual failure scenarios over that model.

The stack combines:

* **Bering** — derives topology and rolling model artifacts from trace/OTLP evidence.
* **Sheaft** — evaluates failure scenarios over those artifacts and produces resilience posture, risk analysis, and optional release-gate decisions.

The continuous mode is intended to track modeled resilience as the observed system topology evolves. The same model can also be used before releases and to prioritize scenarios for live chaos experiments.

### Research evidence

The underlying model-discovery and simulation approach has been evaluated against live fault-injection experiments in two published studies:

* [Model Discovery and Graph Simulation: A Lightweight Gateway to Chaos Engineering](https://conf.researchr.org/details/icse-2026/icse-2026-nier/25/Model-Discovery-and-Graph-Simulation-A-Lightweight-Gateway-to-Chaos-Engineering) — ICSE-NIER 2026, Distinguished Paper Award; evaluated on DeathStarBench.
* [Refining Resilience Model Discovery: A Case Study on the Limited Role of Asynchronous Edges in the OpenTelemetry Demo](https://link.springer.com/chapter/10.1007/978-3-032-23304-2_24) — AINA 2026; evaluated raw OpenTelemetry trace discovery and Monte Carlo resilience simulation against live container-kill experiments on the OpenTelemetry Demo.

Disclosure: I maintain MB3R Stack and am the author of the related research.