### PR TITLE
Add Corelayer to AI SRE Tools & SRE Copilots

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ A curated list of Site Reliability and Production Engineering tools - Maintained
 - [KnoxOps](https://knoxops.app/?invite_token=GITHUB26) - AI-native ops agent that gives agents production-safe execution with human review and a built-in knowledge graph.
 - [NudgeBee](https://nudgebee.com) - Unified AI agentic platform for cloud ops, offering AI SRE, AI FinOps, AI Kubernetes Ops, and AI CloudOps assistants that automate alert triage, root-cause analysis, and cost optimization.
 - [Hyground](https://hyground.ai) - Self-hosted AI SRE agent that goes beyond on-call incident resolution.
+- [Corelayer](https://corelayer.com) - Agentic production support platform that proactively investigates, resolves, and prevents incidents, with BYOC and on-prem support for regulated environments.
 
 ## Related Lists
 


### PR DESCRIPTION
Adds one entry, Corelayer, to the AI SRE Tools & SRE Copilots section.

Entry:

- [Corelayer](https://www.corelayer.com/) - Agentic production support platform that proactively investigates, resolves, and prevents incidents, with BYOC and on-prem support for regulated environments.

Checklist:

- [X] No duplicate entry — searched the section and the open PRs.
- [X] Added at the bottom of the section.
- [X] URL checked, returns 200.
- [X] No new section proposed; the existing AI SRE Tools & SRE Copilots section fits, so the Table of Contents is unchanged.